### PR TITLE
Retries support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,6 @@ it("Can authenticate a valid userS5C123", ...
 ```
 
 4. Install [`@qualitywatcher/wdio-service`](https://www.npmjs.com/package/@qualitywatcher/wdio-service) this reporter works in conjunction with that service.
+
+
+NB: To ensure that we can handle retries properly, we had to make a compromise that all test suite (using the describe block in your code base) must have a unique name. 

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ const REGEX_SUITE_AND_TEST_ID = /\bS(\d+)C(\d+)\b/g;
 
 export default class QualityWatcherReporter extends WDIOReporter {
   private _stateCounts = { passed: 0, failed: 0, skipped: 0, total: 0 };
-  private results = [];
+  private results = new Map();
   private dir = "./QualityWatcher";
 
   constructor(options) {
@@ -37,7 +37,8 @@ export default class QualityWatcherReporter extends WDIOReporter {
       };
 
       if (testCaseDetails.suite_id && testCaseDetails.test_id) {
-        this.results.push(testCaseDetails);
+        const testKey = `${testCaseDetails.suite_id}-${testCaseDetails.test_id}`;
+        this.results.set(testKey, testCaseDetails);
       } else {
         const newCaseData = {
           case: {
@@ -47,7 +48,8 @@ export default class QualityWatcherReporter extends WDIOReporter {
           },
           ...testCaseDetails
         }
-        this.results.push(newCaseData);
+        const testKey = `${test.parent}-${test.title}`;
+        this.results.set(testKey, newCaseData);
       }
     } catch (error) {
       console.error(error);
@@ -58,8 +60,8 @@ export default class QualityWatcherReporter extends WDIOReporter {
     try {
       this.checkDirectory(this.dir);
       fs.writeFileSync(
-        this.dir + `/${suite.uid}[${this.generateRandomString()}].json`,
-        JSON.stringify(this.results)
+        this.dir + `/${suite.title}.json`,
+        JSON.stringify(Array.from(this.results.values()), null, 2)
       );
     } catch (err) {
       console.error(err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualitywatcher/wdio-reporter",
-  "version": "1.0.8",
+  "version": "1.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualitywatcher/wdio-reporter",
-      "version": "1.0.8",
+      "version": "1.0.11",
       "license": "ISC",
       "dependencies": {
         "@wdio/reporter": "^8.32.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualitywatcher/wdio-reporter",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "WebdriverIO Reporter for QualityWatcher",
   "resolveJsonModule": true,
   "main": "index.js",


### PR DESCRIPTION
To properly support retries we had to make some changes:

- Only use the last recorded result for any test when doing a retry
- Only use the last recorded suite when running retries (this meant we had to use suite titles as the file name)
- The user will have to ensure that suite title in describe blocks are unique